### PR TITLE
[feat]: add uuid and timestamp fields in alarm messages

### DIFF
--- a/msg/AlarmStatus.msg
+++ b/msg/AlarmStatus.msg
@@ -1,3 +1,5 @@
+string uuid
+time stamp
 uint16 id
 string description
 string type

--- a/package.xml
+++ b/package.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0"?>
 <package>
   <name>robotnik_alarms_msgs</name>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
   <description>The robotnik_alarms_msgs package. Common messages and services used by some Robotnik's packages.</description>
 
-  <maintainer email="ndiaz@robotnik.es">Nuria Diaz</maintainer>
+  <maintainer email="msanchez@robotnik.es">Miguel Sánchez</maintainer>
+  <maintainer email="rnavarro@robotnik.es">Román Navarro</maintainer>
 
   <license>BSD</license>
 
-  <author email="ndiaz@robotnik.es">Román Navarro</author>
+  <author email="rnavarro@robotnik.es">Román Navarro</author>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>


### PR DESCRIPTION
This pull request includes a modification to the `msg/AlarmStatus.msg` file to enhance the alarm status message format.

* [`msg/AlarmStatus.msg`](diffhunk://#diff-c98f7b174243e89df6e7a2f461dc3d6ac455535648a3a3336483659358c67839R1-R2): Added `uuid` and `stamp` fields to the alarm status message.